### PR TITLE
删除无意义的配置

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -272,11 +272,6 @@ nnoremap <leader>o :YcmCompleter GoToInclude<cr>
 nnoremap <leader>ff :YcmCompleter FixIt<cr>
 nmap <F5> :YcmDiags<cr>
 
-" ctags
-set tags+=/usr/include/tags
-set tags+=~/.vim/systags
-set tags+=~/.vim/x86_64-linux-gnu-systags
-
 " tagbar
 let g:tagbar_width = 30
 nnoremap <silent> <leader>t :TagbarToggle<cr>


### PR DESCRIPTION
用户本地很可能不存在这些自定义生成的文件