### PR TITLE
Modify install files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -398,7 +398,7 @@ function install_ycm()
     cd ~/.vim/plugged/YouCompleteMe
 
     read -p "Please choose to compile ycm with python2 or python3, if there is a problem with the current selection, please choose another one. [2/3] " version
-    if [ $version == "2" ]; then
+    if [[ $version == "2" ]]; then
         echo "Compile ycm with python2."
         python2.7 ./install.py --clang-completer
     else


### PR DESCRIPTION
I got an error when I run `install.sh` in my dockerfile.

```sh
./install.sh: line 404: [: ==: unary operator expected
```

`$version` will be empty when I run `docker build ...`, the shell will become `if [ == "2" ]; then`.

So I add a pair `[]` to prevent showing that error, and it will use python3 in default.